### PR TITLE
Change creator type from 'MPS ' to 'BITP'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ HFSDM=/Applications/HFS\ Disk\ Maker.app/Contents/MacOS/hfs_disk_maker_cli
 
 RINCLUDES=/Applications/MPW-GM/Interfaces\&Libraries/Interfaces/RIncludes
 
-LDFLAGS =-w -c 'MPS ' -t APPL \
+LDFLAGS =-w -c 'BITP' -t APPL \
 	-sn STDIO=Main -sn INTENV=Main -sn %A5Init=Main
 
-PPC_LDFLAGS =-m main -w -c 'MPS ' -t APPL
+PPC_LDFLAGS =-m main -w -c 'BITP' -t APPL
 
 USE_CARBON=1
 


### PR DESCRIPTION
This gives the executable its own creator type that doesn't conflict with MPW, allowing the 68k binary app to run without problems on a System 7 Mac that has MPW installed and present. Otherwise, the assembled binary will refuse to open when MPW is installed locally; instead of running as expected, you'll receive an alert reading “This version of MPW is not compatible with your system”.